### PR TITLE
chore: introduced local build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.west
+zephyr
+modules
+zmk
+artifacts
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # kb54_zmk_config
+
+## Build
+
+### Local build
+
+It is possible to build the firmware locally using docker. Under scripts directory, there are utility scripts to build the firmware.
+
+```bash
+./scripts/docker.build.sh
+```
+
+After the build script is executed, the firmware files will be available under the `artifacts` directory.
+
+Without docker, the complete toolchain for zmk has to be locally available. After that, the firmware can be built using the following command.
+
+```bash
+HOME_DIR=$(pwd) ./scripts/build.sh
+```
+
+During the build process, all necessary files will be downloaded in the current repository directory. To clean up the repo and restore it to the original state, the following command can be used.
+
+```bash
+./scripts/clean.sh
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ It is possible to build the firmware locally using docker. Under scripts directo
 
 After the build script is executed, the firmware files will be available under the `artifacts` directory.
 
+An optional argument can be passed to the build script to specify artifact directory as follows:
+```bash
+./scripts/docker.build.sh kb54_workstation
+
+# and the binaries will be available under this directory
+# ./artifacts/kb54_workstation
+```
+
 Without docker, the complete toolchain for zmk has to be locally available. After that, the firmware can be built using the following command.
 
 ```bash

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -x
+
+ZEPHYR_VERSION=3.5.0
+
+# Check if HOME_DIR is set
+if [ -z "$HOME_DIR" ]
+then
+  echo "HOME_DIR is not set"
+  exit 1
+fi
+
+ZMK_CONFIG="$HOME_DIR/config"
+
+cd $HOME_DIR
+west init -l ./config
+
+set -e
+west update
+west zephyr-export
+
+function build_firmware {
+  DISPLAY_NAME=$1
+  BUILD_DIR=$2
+  ARTIFACT_NAME="${DISPLAY_NAME}-zmk"
+  west build -s zmk/app -d $BUILD_DIR -b $DISPLAY_NAME -- -DZMK_CONFIG=$ZMK_CONFIG
+
+  # Kconfig file
+  if [ -f "$BUILD_DIR/zephyr/.config" ]
+  then
+    grep -v -e "^#" -e "^$" "$BUILD_DIR/zephyr/.config" | sort
+  else
+    echo "No Kconfig output"
+  fi
+
+  # Devicetree file
+  if [ -f "$BUILD_DIR/zephyr/zephyr.dts" ]
+  then
+    cat "$BUILD_DIR/zephyr/zephyr.dts"
+  elif [ -f "$BUILD_DIR/zephyr/zephyr.dts.pre" ]
+  then
+    cat -s "$BUILD_DIR/zephyr/zephyr.dts.pre"
+  else
+    echo "No Devicetree output"
+  fi
+
+  # Rename artifacts
+  mkdir "$BUILD_DIR/artifacts"
+  if [ -f "$BUILD_DIR/zephyr/zmk.uf2" ]
+  then
+    cp "$BUILD_DIR/zephyr/zmk.uf2" "$BUILD_DIR/artifacts/$ARTIFACT_NAME.uf2"
+  elif [ -f "$BUILD_DIR/zephyr/zmk.uf2" ]
+  then
+    cp "$BUILD_DIR/zephyr/zmk.uf2" "$BUILD_DIR/artifacts/$ARTIFACT_NAME.uf2"
+  fi
+}
+
+
+DISPLAY_NAME_L=kb54_nrf52840_l
+BUILD_DIR_L="$(mktemp -d)"
+build_firmware $DISPLAY_NAME_L $BUILD_DIR_L
+
+DISPLAY_NAME_R=kb54_nrf52840_r
+BUILD_DIR_R="$(mktemp -d)"
+build_firmware $DISPLAY_NAME_R $BUILD_DIR_R
+
+# Copy artifacts into home directory
+cp -r $BUILD_DIR_L/artifacts $HOME_DIR
+rm -rf $BUILD_DIR_L
+cp -r $BUILD_DIR_R/artifacts $HOME_DIR
+rm -rf $BUILD_DIR_R
+
+ls -l $HOME_DIR/artifacts
+

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,10 +3,14 @@ set -x
 
 ZEPHYR_VERSION=3.5.0
 
-# Check if HOME_DIR is set
 if [ -z "$HOME_DIR" ]
 then
   echo "HOME_DIR is not set"
+  exit 1
+fi
+if [ -z "$ARTIFACT_DIR" ]
+then
+  echo "ARTIFACT_DIR is not set"
   exit 1
 fi
 
@@ -65,10 +69,11 @@ BUILD_DIR_R="$(mktemp -d)"
 build_firmware $DISPLAY_NAME_R $BUILD_DIR_R
 
 # Copy artifacts into home directory
-cp -r $BUILD_DIR_L/artifacts $HOME_DIR
+mkdir -p $ARTIFACT_DIR
+cp -r $BUILD_DIR_L/artifacts/* $ARTIFACT_DIR/
 rm -rf $BUILD_DIR_L
-cp -r $BUILD_DIR_R/artifacts $HOME_DIR
+cp -r $BUILD_DIR_R/artifacts/* $ARTIFACT_DIR/
 rm -rf $BUILD_DIR_R
 
-ls -l $HOME_DIR/artifacts
+ls -l $ARTIFACT_DIR
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
+SOURCE_DIR="$(realpath "${SCRIPT_DIR}/../")"
+CONTAINER_NAME=kb54_firmware_build
+docker stop $CONTAINER_NAME
+docker rm $CONTAINER_NAME
+
+rm -rf "$SOURCE_DIR/../zephyr/.git"
+# Clean up all untracked files
+git clean -ffdx

--- a/scripts/docker.build.sh
+++ b/scripts/docker.build.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 set -ex
 
+ARTIFACT_NAME=$1
+if [ -z "$ARTIFACT_NAME" ]; then
+  ARTIFACT_NAME=kb54_nrf52840
+  echo "No artifact name provided, using default: $ARTIFACT_NAME"
+fi
+
 SCRIPT_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
 SOURCE_DIR="$(realpath "${SCRIPT_DIR}/../")"
 TARGET_DIR=/home/ubuntu/kb54_zmk_config
 CONTAINER_NAME=kb54_firmware_build
 IMAGE_NAME=zmkfirmware/zmk-build-arm:stable
+ARTIFACT_DIR="${TARGET_DIR}/artifacts/${ARTIFACT_NAME}"
 
 if ! [ -x "$(command -v docker)" ]; then
   echo "Error: docker is not installed." >&2
@@ -22,4 +29,5 @@ docker run -it\
   -v $SOURCE_DIR:$TARGET_DIR \
   --entrypoint "/bin/bash" \
   -e HOME_DIR=$TARGET_DIR \
+  -e ARTIFACT_DIR=$ARTIFACT_DIR \
   $IMAGE_NAME "$TARGET_DIR/scripts/build.sh"

--- a/scripts/docker.build.sh
+++ b/scripts/docker.build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+
+SCRIPT_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
+SOURCE_DIR="$(realpath "${SCRIPT_DIR}/../")"
+TARGET_DIR=/home/ubuntu/kb54_zmk_config
+CONTAINER_NAME=kb54_firmware_build
+IMAGE_NAME=zmkfirmware/zmk-build-arm:stable
+
+if ! [ -x "$(command -v docker)" ]; then
+  echo "Error: docker is not installed." >&2
+  exit 1
+fi
+
+if [ "$(docker ps --all -q -f name=$CONTAINER_NAME)" ]; then
+  docker stop $CONTAINER_NAME
+  docker rm $CONTAINER_NAME
+fi
+
+docker run -it\
+  --name $CONTAINER_NAME \
+  -v $SOURCE_DIR:$TARGET_DIR \
+  --entrypoint "/bin/bash" \
+  -e HOME_DIR=$TARGET_DIR \
+  $IMAGE_NAME "$TARGET_DIR/scripts/build.sh"


### PR DESCRIPTION
The following change includes scripts that help generating firmware files in local machine. This is an alternative to the GitHub actions. One advantage of using local builds is shortened feedback cycle between builds.

The build script leverages docker image for zmk arm builds. The integrity of the generated firmware files have been verified using `cmp` and `sha256sum`.